### PR TITLE
Use org mode 9 org-link-set-parameters

### DIFF
--- a/contrib/lisp/org-notmuch.el
+++ b/contrib/lisp/org-notmuch.el
@@ -44,8 +44,10 @@
 (require 'org)
 
 ;; Install the link type
-(org-add-link-type "notmuch" 'org-notmuch-open)
-(add-hook 'org-store-link-functions 'org-notmuch-store-link)
+(org-link-set-parameters
+ "notmuch"
+ :follow 'org-notmuch-open
+ :store 'org-notmuch-store-link)
 
 (defun org-notmuch-store-link ()
   "Store a link to a notmuch search or message."
@@ -76,8 +78,10 @@ Can link to more than one message, if so all matching messages are shown."
 
 
 
-(org-add-link-type "notmuch-search" 'org-notmuch-search-open)
-(add-hook 'org-store-link-functions 'org-notmuch-search-store-link)
+(org-link-set-parameters
+ "notmuch-search"
+ :follow 'org-notmuch-search-open
+ :store 'org-notmuch-search-store-link)
 
 (defun org-notmuch-search-store-link ()
   "Store a link to a notmuch search or message."


### PR DESCRIPTION
`org-mode` 9 changed the way new link types are defined. This patch updates `org-notmuch` to use the new `org-link-set-parameters` function. The old style does not work anymore.